### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/danilouchoa/liga-crypto-notifier-bot/security/code-scanning/1](https://github.com/danilouchoa/liga-crypto-notifier-bot/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for checking out the repository code.
- `statuses: write` for updating commit statuses (if applicable).
- `id-token: write` for any OpenID Connect token usage (if applicable).
- Additional permissions for specific jobs, such as `contents: write` for deployment or `security-events: write` for security-related actions.

We will start with a minimal `permissions` block and adjust it as needed for specific jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
