### PR TITLE
fix(security): reforça headers HTTP para eliminar alertas ZAP (Issue #9)

### DIFF
--- a/middlewares/applySecurityHeaders.js
+++ b/middlewares/applySecurityHeaders.js
@@ -3,16 +3,37 @@
 function setSecurityHeaders(res) {
   res.setHeader(
     'Content-Security-Policy',
-    "default-src 'self'; frame-ancestors 'none'"
+    [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self'",
+      "img-src 'self' data:",
+      "font-src 'self'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "frame-ancestors 'none'",
+    ].join('; ')
   );
-  res.setHeader('Permissions-Policy', 'fullscreen=(), geolocation=()');
+
+  res.setHeader(
+    'Permissions-Policy',
+    'camera=(), microphone=(), geolocation=(), fullscreen=()'
+  );
+
   res.setHeader(
     'Strict-Transport-Security',
     'max-age=63072000; includeSubDomains; preload'
   );
+
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Referrer-Policy', 'no-referrer');
+
+  // Segurança contra Spectre
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+
+  // Cache seguro (pode ser customizado por rota)
   res.setHeader('Cache-Control', 'no-store');
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,8 +38,15 @@ app.get(['/robots.txt', '/sitemap.xml'], (req, res) => {
     'Permissions-Policy',
     'camera=(), microphone=(), geolocation=()'
   );
-  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader(
+    'Cache-Control',
+    'no-store, no-cache, must-revalidate, proxy-revalidate'
+  );
   res.setHeader('Referrer-Policy', 'no-referrer');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
   res.status(404).send('Not found');
 });
 


### PR DESCRIPTION
Este PR implementa a correção da Issue #9 reportada pelo OWASP ZAP, reforçando as políticas de segurança por meio de headers HTTP aplicados globalmente via middleware applySecurityHeaders, e especificamente para os endpoints /robots.txt e /sitemap.xml.

Principais melhorias:

Aplicação rigorosa da Content-Security-Policy (CSP) com fallback (default-src 'self') e bloqueio de unsafe-inline.

Adição dos headers Cross-Origin-Opener-Policy e Cross-Origin-Embedder-Policy para mitigar vulnerabilidades Spectre.

Remoção do uso de cache e frame embedding com Cache-Control, X-Frame-Options e Referrer-Policy.

Padronização de Permissions-Policy para bloquear acesso a recursos sensíveis por crawlers e navegadores.

Tratamento específico para /robots.txt e /sitemap.xml com headers mínimos e seguros.

Resultado esperado:

Nenhum impacto no funcionamento do Swagger UI.

Eliminação dos alertas ZAP relacionados aos códigos [10055], [90003], [10017], [90004], [10109] e [10049].

Alinhamento com as boas práticas recomendadas pelo OWASP para aplicações modernas.

Closes #9
