### PR TITLE
docs(security): atualiza SECURITY.md com política aplicada de headers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,3 @@
----
-
-## 📁 `SECURITY.md`
-
-```md
 # 🛡️ Política de Segurança – Liga Crypto Notifier Bot
 
 Este projeto segue a filosofia **Secure by Default**, adotando padrões avançados de segurança web e integração contínua com ferramentas de análise estática e dinâmica.
@@ -11,63 +6,65 @@ Este projeto segue a filosofia **Secure by Default**, adotando padrões avançad
 
 ## 🔐 Cabeçalhos de Segurança (HTTP Security Headers)
 
-Todos os endpoints (incluindo `/`, `/docs`, `/robots.txt`, `/sitemap.xml`, 404s e redirecionamentos) aplicam os seguintes headers:
+Todos os endpoints da aplicação — incluindo `/`, `/docs`, `/robots.txt`, `/sitemap.xml`, redirecionamentos e respostas 404 — aplicam os seguintes headers:
 
-- `Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'`
-- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+- `Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=(), fullscreen=()`
 - `Referrer-Policy: no-referrer`
-- `Cache-Control: no-store`
+- `Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate`
 - `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
 - `X-Frame-Options: DENY`
 - `X-Content-Type-Options: nosniff`
-- `X-Permitted-Cross-Domain-Policies: none`
-- `X-XSS-Protection: 0`
-- `X-DNS-Prefetch-Control: off`
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: require-corp`
 
-Esses headers são aplicados de forma centralizada por meio dos seguintes módulos:
+Esses headers são aplicados por meio dos seguintes middlewares:
 
-| Middleware               | Função                                                          |
-| ------------------------ | --------------------------------------------------------------- |
-| `securityMiddleware()`   | Aplica Helmet com CSP e outros headers                          |
-| `secure404()`            | Aplica headers seguros em rotas inexistentes                    |
-| `rootRedirect()`         | Redireciona `/` para `/docs` com proteção                       |
-| `applySecurityHeaders()` | Função utilitária para aplicação de headers em respostas custom |
+| Middleware               | Função                                                         |
+| ------------------------ | -------------------------------------------------------------- |
+| `applySecurityHeaders()` | Middleware global para todos os endpoints padrão               |
+| `secure404()`            | Aplica headers seguros em rotas inexistentes                   |
+| `rootRedirect()`         | Redireciona `/` para `/docs` com proteção                      |
+| `crawlerHeaders()`       | Aplica headers específicos para `/robots.txt` e `/sitemap.xml` |
 
 ---
 
 ## 🧪 Testes de Segurança Automatizados
 
-Este projeto utiliza DevSecOps com escaneamento contínuo:
+Este projeto integra práticas DevSecOps com escaneamento contínuo:
 
-- **OWASP ZAP** (DAST): executado automaticamente na pipeline, validando vulnerabilidades em tempo de execução
-- **Snyk**: análise de dependências (SCA) para detectar CVEs conhecidas
-- **Gitleaks**: verificação de vazamentos de segredos no repositório
+- **OWASP ZAP** (DAST): executado automaticamente na pipeline CI/CD para detectar falhas de runtime (XSS, CSP, SRI, etc.)
+- **Snyk**: análise de dependências (SCA) para identificar CVEs
+- **Semgrep**: análise estática de código (SAST) complementar
+- **Gitleaks**: verificação de exposição de segredos
+- **CodeQL**: análise semântica de vulnerabilidades lógicas no código
 
 ---
 
 ## 🔄 Gestão Inteligente de Issues
 
-- Issues são **criadas automaticamente** via GitHub Actions se alertas forem detectados pelo ZAP
-- Script customizado analisa o `report_json.json` e **fecha issues automaticamente** se o alerta for removido em um novo commit
-- Tudo isso é auditável no workflow `pipeline.yml`
+- Issues de segurança são **criadas automaticamente** via GitHub Actions com base nos alertas do ZAP
+- O workflow identifica e **fecha automaticamente** a issue quando a vulnerabilidade for resolvida em novo commit
+- O processo é auditável via histórico de workflow no `ci.yml`
 
 ---
 
 ## 🧱 Arquitetura Segura
 
-- Sem push direto na `main` (branch protegida)
-- Commits validados com Husky e Commitlint
-- CSP sem `*`, com fallback explícito
-- Redirecionamentos e 404s seguros com headers robustos
-- Segurança modularizada em middlewares independentes
+- Branch `main` protegida (sem push direto)
+- Commits validados com Husky, lint-staged e Commitlint
+- CSP sem curingas (`*`), com fallback explícito e sem `unsafe-inline`
+- Headers de segurança aplicados de forma centralizada e modular
+- Redirecionamentos e erros 404 respondem com políticas CSP e ReferrerPolicy consistentes
 
 ---
 
 ## 📬 Reportar Vulnerabilidades
 
-Caso identifique alguma falha de segurança:
+Caso você identifique qualquer falha de segurança:
 
-1. Abra uma issue marcada com a tag `security`
+1. Abra uma issue com a tag `security`
+2. Detalhe ao máximo a falha observada ou suspeita
 
 Responderemos com prioridade.
 


### PR DESCRIPTION
Este PR atualiza o arquivo SECURITY.md para refletir fielmente os headers de segurança implementados no middleware applySecurityHeaders, cobrindo a correção aplicada na Issue #19 (OWASP ZAP).

Atualizações incluídas:

Detalhamento completo da política Content-Security-Policy, agora com fallback default-src 'self' e bloqueio de unsafe-inline;

Inclusão dos headers Cross-Origin-Opener-Policy e Cross-Origin-Embedder-Policy, aplicados globalmente;

Mapeamento claro de quais middlewares aplicam cada conjunto de headers;

Registro das ferramentas DevSecOps utilizadas (ZAP, Snyk, Semgrep, CodeQL, Gitleaks);

Seção de governança com gestão automática de issues de segurança;

Revisão da seção de arquitetura segura e política de commits protegidos.

Resultado esperado:

Documentação fiel à implementação real;

Conformidade com as boas práticas de segurança recomendadas pelo OWASP;

Base de referência para novas contribuições com foco em segurança.