### PR TITLE
docs(license): adiciona LICENSE.md e define licença MIT no package.json

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Danilo Uchoa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "webhook",
     "liga-crypto"
   ],
-  "author": "Danilo",
-  "license": "ISC",
+  "license": "MIT",
+  "author": "Danilo Uchoa",
   "engines": {
     "node": ">=20 <23"
   },


### PR DESCRIPTION
Este PR adiciona o arquivo LICENSE.md com a licença MIT, garantindo que o projeto siga boas práticas de código aberto e forneça segurança jurídica para uso, modificação e distribuição.

Alterações incluídas:

Inclusão do arquivo LICENSE.md com a licença MIT (Danilo Uchoa, 2025);

Atualização do campo "license" no package.json para "MIT";

Adição do campo "author" como Danilo Uchoa no package.json.

Motivação:

Permitir o uso livre e legal do código por terceiros;

Facilitar integrações com ferramentas como GitHub Actions, Snyk e Dependabot;

Reforçar a conformidade com práticas DevSecOps e governança open source.